### PR TITLE
Change Reaper-kb.ini to reaper-kb.ini

### DIFF
--- a/MachineView/OpenMachineView.lua
+++ b/MachineView/OpenMachineView.lua
@@ -86,7 +86,7 @@ end
 local function preMain()
   reaper.SetProjExtState(0, extStateIdx, focusTag, tonumber(1))
   
-  local fn = reaper.GetResourcePath() .. '//' .. "Reaper-kb.ini"
+  local fn = reaper.GetResourcePath() .. '//' .. "reaper-kb.ini"
   local f = io.open(fn, "r")
   if f then
     commandID = findCommandID(fn, scriptName)


### PR DESCRIPTION
Unix-like operating systems such as macOS and Linux cannot read reaper-kb.ini
because it is case-sensitive. This makes the file name lower case.